### PR TITLE
Improve garbage collection

### DIFF
--- a/packages/replicad/src/Sketcher.ts
+++ b/packages/replicad/src/Sketcher.ts
@@ -57,7 +57,6 @@ export default class Sketcher implements GenericSketcher<Sketch> {
   }
 
   protected _updatePointer(newPointer: Vector): void {
-    this.pointer.delete();
     this.pointer = newPointer;
   }
 
@@ -67,7 +66,6 @@ export default class Sketcher implements GenericSketcher<Sketch> {
         "You can only move the pointer if there is no edge defined"
       );
     this._updatePointer(this.plane.toWorldCoords([x, y]));
-    this.firstPoint.delete();
     this.firstPoint = new Vector(this.pointer);
     return this;
   }
@@ -170,21 +168,17 @@ export default class Sketcher implements GenericSketcher<Sketch> {
 
     let p = endPoint.add(startPoint);
     const midPoint = p.multiply(0.5);
-    p.delete();
 
     p = endPoint.sub(startPoint);
     const sagDirection = p.cross(this.plane.zDir).normalized();
 
-    p.delete();
     const sagVector = sagDirection.multiply(sagitta);
 
     const sagPoint = midPoint.add(sagVector);
-    sagVector.delete();
 
     this.pendingEdges.push(makeThreePointArc(this.pointer, sagPoint, endPoint));
     this._updatePointer(endPoint);
 
-    sagPoint.delete();
     return this;
   }
 
@@ -279,7 +273,6 @@ export default class Sketcher implements GenericSketcher<Sketch> {
   halfEllipseTo(end: Point2D, verticalRadius: number, sweep = false): this {
     const pointer = this.plane.toLocalCoords(this.pointer);
     const start: Point2D = [pointer.x, pointer.y];
-    pointer.delete();
 
     const angle = angle2d(end, start);
     const distance = distance2d(end, start);
@@ -412,7 +405,6 @@ export default class Sketcher implements GenericSketcher<Sketch> {
     const mirroredWire = wire.clone().mirror(normal, this.pointer);
 
     const combinedWire = assembleWire([wire, mirroredWire]);
-    mirroredWire.delete();
 
     return combinedWire;
   }
@@ -422,14 +414,11 @@ export default class Sketcher implements GenericSketcher<Sketch> {
       throw new Error("No lines to convert into a wire");
 
     let wire = assembleWire(this.pendingEdges);
-    this.pendingEdges.forEach((e) => e.delete());
 
     if (this._mirrorWire) {
       wire = this._mirrorWireOnStartEnd(wire);
     }
 
-    this.pointer.delete();
-    this.firstPoint.delete();
     return wire;
   }
 
@@ -445,7 +434,6 @@ export default class Sketcher implements GenericSketcher<Sketch> {
       defaultOrigin: this.plane.origin,
       defaultDirection: this.plane.zDir,
     });
-    this.delete();
     return sketch;
   }
 

--- a/packages/replicad/src/Sketcher.ts
+++ b/packages/replicad/src/Sketcher.ts
@@ -1,6 +1,6 @@
 import { Plane, PlaneName, Point, Vector } from "./geom";
 import { makePlane } from "./geomHelpers";
-import { localGC, RegisteredObj } from "./register";
+import { localGC } from "./register";
 import { DEG2RAD, RAD2DEG } from "./constants";
 import { distance2d, angle2d, polarToCartesian, Point2D } from "./lib2d";
 import {
@@ -27,10 +27,7 @@ import Sketch from "./sketches/Sketch.js";
  *
  * @category Sketching
  */
-export default class Sketcher
-  extends RegisteredObj
-  implements GenericSketcher<Sketch>
-{
+export default class Sketcher implements GenericSketcher<Sketch> {
   protected plane: Plane;
   protected pointer: Vector;
   protected firstPoint: Vector;
@@ -45,8 +42,6 @@ export default class Sketcher
   constructor(plane: Plane);
   constructor(plane?: PlaneName, origin?: Point | number);
   constructor(plane?: Plane | PlaneName, origin?: Point) {
-    super();
-
     this.plane =
       plane instanceof Plane ? makePlane(plane) : makePlane(plane, origin);
 
@@ -59,7 +54,6 @@ export default class Sketcher
 
   delete(): void {
     this.plane.delete();
-    super.delete();
   }
 
   protected _updatePointer(newPointer: Vector): void {

--- a/packages/replicad/src/blueprints/Blueprint.ts
+++ b/packages/replicad/src/blueprints/Blueprint.ts
@@ -17,7 +17,7 @@ import { assembleWire } from "../shapeHelpers";
 import { Face } from "../shapes";
 import Sketch from "../sketches/Sketch";
 
-import { localGC } from "../register";
+import { localGC, GCWithObject } from "../register";
 import { getOC } from "../oclib.js";
 import { Plane, PlaneName, Point } from "../geom";
 import { DEG2RAD } from "../constants";
@@ -34,6 +34,9 @@ export default class Blueprint implements BlueprintInterface {
   protected _boundingBox: null | BoundingBox2d;
   constructor(curves: Geom2d_Curve[]) {
     this.curves = curves;
+
+    const registerForGC = GCWithObject(this);
+    this.curves.forEach(registerForGC);
     this._boundingBox = null;
   }
 
@@ -120,7 +123,6 @@ export default class Blueprint implements BlueprintInterface {
 
     const edges = curvesAsEdgesOnPlane(this.curves, plane);
     const wire = assembleWire(edges);
-    edges.forEach((e) => e.delete());
 
     return new Sketch(wire, {
       defaultOrigin: plane.origin,
@@ -134,7 +136,6 @@ export default class Blueprint implements BlueprintInterface {
 
     const edges = curvesAsEdgesOnFace(this.curves, face, scaleMode);
     const wire = assembleWire(edges);
-    edges.forEach((e) => e.delete());
 
     oc.BRepLib.BuildCurves3d_2(wire.wrapped);
 

--- a/packages/replicad/src/finders.ts
+++ b/packages/replicad/src/finders.ts
@@ -1,6 +1,5 @@
 import { Vector, asPnt, Point, Plane, PlaneName } from "./geom";
 import { makePlane } from "./geomHelpers";
-import { RegisteredObj } from "./register";
 import { DEG2RAD } from "./constants";
 import { Face, Edge, AnyShape, SurfaceType, CurveType } from "./shapes";
 import { getOC } from "./oclib";
@@ -22,7 +21,7 @@ const PLANE_TO_DIR: Record<StandardPlane, [number, number, number]> = {
 
 type FaceOrEdge = Face | Edge;
 
-abstract class Finder<Type extends FaceOrEdge> extends RegisteredObj {
+abstract class Finder<Type extends FaceOrEdge> {
   protected filters: (({
     element,
     normal,
@@ -41,7 +40,6 @@ abstract class Finder<Type extends FaceOrEdge> extends RegisteredObj {
   abstract shouldKeep(t: Type): boolean;
 
   constructor() {
-    super();
     this.filters = [];
     this.references = [];
   }
@@ -50,7 +48,6 @@ abstract class Finder<Type extends FaceOrEdge> extends RegisteredObj {
     this.references.forEach((r) => r.delete());
     this.references = [];
     this.filters = [];
-    super.delete();
   }
 
   /**

--- a/packages/replicad/src/finders.ts
+++ b/packages/replicad/src/finders.ts
@@ -281,7 +281,6 @@ export class FaceFinder extends Finder<Face> {
     if (typeof plane !== "string" && plane.normalAt) {
       const normal = plane.normalAt();
       this.atAngleWith(normal);
-      normal.delete();
       return this;
     }
     return this;
@@ -320,9 +319,6 @@ export class FaceFinder extends Finder<Face> {
       const projectedPoint = point.projectToPlane(plane);
 
       const isSamePoint = point.equals(projectedPoint);
-      point.delete();
-      projectedPoint.delete();
-
       return isSamePoint;
     };
 
@@ -335,14 +331,12 @@ export class FaceFinder extends Finder<Face> {
     const shouldKeep = this.filters.every((filter) =>
       filter({ normal, element })
     );
-    normal.delete();
     return shouldKeep;
   }
 
   protected applyFilter(shape: AnyShape): Face[] {
     return shape.faces.filter((face: Face) => {
       const shouldKeep = this.shouldKeep(face);
-      if (!shouldKeep) face.delete();
       return shouldKeep;
     });
   }
@@ -393,7 +387,6 @@ export class EdgeFinder extends Finder<Edge> {
     if (typeof plane !== "string" && plane.normalAt) {
       const normal = plane.normalAt();
       this.atAngleWith(normal, 90);
-      normal.delete();
       return this;
     }
     return this;
@@ -420,8 +413,6 @@ export class EdgeFinder extends Finder<Edge> {
       const projectedPoint = point.projectToPlane(plane);
 
       const isSamePoint = point.equals(projectedPoint);
-      point.delete();
-      projectedPoint.delete();
 
       return isSamePoint;
     };
@@ -435,14 +426,12 @@ export class EdgeFinder extends Finder<Edge> {
     const shouldKeep = this.filters.every((filter) =>
       filter({ normal, element })
     );
-    normal.delete();
     return shouldKeep;
   }
 
   protected applyFilter(shape: AnyShape): Edge[] {
     return shape.edges.filter((edge: Edge) => {
       const shouldKeep = this.shouldKeep(edge);
-      if (!shouldKeep) edge.delete();
       return shouldKeep;
     });
   }

--- a/packages/replicad/src/geom.ts
+++ b/packages/replicad/src/geom.ts
@@ -1,4 +1,4 @@
-import { WrappingObj,  GCWithScope } from "./register.js";
+import { WrappingObj, GCWithScope } from "./register.js";
 import { DEG2RAD, RAD2DEG } from "./constants.js";
 import { getOC } from "./oclib.js";
 
@@ -197,11 +197,6 @@ export function asDir(coords: Point): gp_Dir {
   const dir = v.toDir();
   v.delete();
   return dir;
-}
-
-export function asVec(coords: Point): gp_Vec {
-  const v = new Vector(coords);
-  return v.wrapped;
 }
 
 type CoordSystem = "reference" | { origin: Point; zDir: Point; xDir: Point };

--- a/packages/replicad/src/geom.ts
+++ b/packages/replicad/src/geom.ts
@@ -1,4 +1,4 @@
-import { WrappingObj, RegisteredObj, localGC } from "./register.js";
+import { WrappingObj,  GCWithScope } from "./register.js";
 import { DEG2RAD, RAD2DEG } from "./constants.js";
 import { getOC } from "./oclib.js";
 
@@ -241,7 +241,7 @@ export class Transformation extends WrappingObj<gp_Trsf> {
     inputPlane: Plane | PlaneName | Point = "YZ",
     inputOrigin?: Point
   ): this {
-    const [r, gc] = localGC();
+    const r = GCWithScope();
 
     let origin: Point;
     let direction: Point;
@@ -260,7 +260,6 @@ export class Transformation extends WrappingObj<gp_Trsf> {
 
     const mirrorAxis = r(makeAx2(origin, direction));
     this.wrapped.SetMirror_3(mirrorAxis);
-    gc();
 
     return this;
   }
@@ -273,7 +272,7 @@ export class Transformation extends WrappingObj<gp_Trsf> {
   }
 
   coordSystemChange(fromSystem: CoordSystem, toSystem: CoordSystem): this {
-    const [r, gc] = localGC();
+    const r = GCWithScope();
     const fromAx = r(
       fromSystem === "reference"
         ? new this.oc.gp_Ax3_1()
@@ -286,7 +285,6 @@ export class Transformation extends WrappingObj<gp_Trsf> {
         : makeAx3(toSystem.origin, toSystem.zDir, toSystem.xDir)
     );
     this.wrapped.SetTransformation_1(fromAx, toAx);
-    gc();
     return this;
   }
 
@@ -307,7 +305,7 @@ export class Transformation extends WrappingObj<gp_Trsf> {
   }
 }
 
-export class Plane extends RegisteredObj {
+export class Plane {
   oc: OpenCascadeInstance;
 
   xDir: Vector;
@@ -326,7 +324,6 @@ export class Plane extends RegisteredObj {
     xDirection: Point | null = null,
     normal: Point = [0, 0, 1]
   ) {
-    super();
     this.oc = getOC();
 
     const zDir = new Vector(normal);
@@ -360,7 +357,6 @@ export class Plane extends RegisteredObj {
     this.yDir.delete();
     this.zDir.delete();
     this._origin.delete();
-    super.delete();
   }
 
   clone(): Plane {

--- a/packages/replicad/src/index.ts
+++ b/packages/replicad/src/index.ts
@@ -1,7 +1,7 @@
 import Sketcher from "./Sketcher";
 import FaceSketcher, { BaseSketcher2d, BlueprintSketcher } from "./Sketcher2d";
 
-import { Point2D, BoundingBox2d } from "./lib2d";
+import { Point2D, BoundingBox2d, Curve2D } from "./lib2d";
 import { GenericSketcher, SplineConfig } from "./sketcherlib";
 
 export {
@@ -13,6 +13,7 @@ export {
   Point2D,
   BlueprintSketcher,
   BoundingBox2d,
+  Curve2D,
 };
 
 export * from "./constants";

--- a/packages/replicad/src/register.ts
+++ b/packages/replicad/src/register.ts
@@ -54,6 +54,15 @@ export const GCWithScope = () => {
   return gcWithScope;
 };
 
+export const GCWithObject = (obj: any) => {
+  function registerForGC<Type extends Deletable>(value: Type): Type {
+    deletetableRegistry.register(obj, value);
+    return value;
+  }
+
+  return registerForGC;
+};
+
 export const localGC = (
   debug?: boolean
 ): [

--- a/packages/replicad/src/register.ts
+++ b/packages/replicad/src/register.ts
@@ -5,8 +5,11 @@ interface Deletable {
   delete: () => void;
 }
 const deletetableRegistry = new FinalizationRegistry((heldValue: Deletable) => {
-  console.log("deleting wrapped");
-  heldValue.delete();
+  try {
+    heldValue.delete();
+  } catch (e) {
+    console.error(e);
+  }
 });
 
 export class WrappingObj<Type extends Deletable> {

--- a/packages/replicad/src/register.ts
+++ b/packages/replicad/src/register.ts
@@ -15,6 +15,7 @@ if (!(globalThis as any).FinalizationRegistry) {
 const deletetableRegistry = new (globalThis as any).FinalizationRegistry(
   (heldValue: Deletable) => {
     try {
+      console.log("gc!");
       heldValue.delete();
     } catch (e) {
       console.error(e);
@@ -28,8 +29,6 @@ export class WrappingObj<Type extends Deletable> {
 
   constructor(wrapped: Type) {
     this.oc = getOC();
-    if (!this.oc) console.log("wrapping", this.oc);
-
     if (wrapped) {
       deletetableRegistry.register(this, wrapped, wrapped);
     }

--- a/packages/replicad/src/register.ts
+++ b/packages/replicad/src/register.ts
@@ -4,13 +4,23 @@ import { OpenCascadeInstance } from "replicad-opencascadejs";
 interface Deletable {
   delete: () => void;
 }
-const deletetableRegistry = new FinalizationRegistry((heldValue: Deletable) => {
-  try {
-    heldValue.delete();
-  } catch (e) {
-    console.error(e);
+
+if (!(globalThis as any).FinalizationRegistry) {
+  (globalThis as any).FinalizationRegistry = (() => ({
+    register: () => null,
+    unregister: () => null,
+  })) as any;
+}
+
+const deletetableRegistry = new (globalThis as any).FinalizationRegistry(
+  (heldValue: Deletable) => {
+    try {
+      heldValue.delete();
+    } catch (e) {
+      console.error(e);
+    }
   }
-});
+);
 
 export class WrappingObj<Type extends Deletable> {
   protected oc: OpenCascadeInstance;

--- a/packages/replicad/src/register.ts
+++ b/packages/replicad/src/register.ts
@@ -15,7 +15,6 @@ if (!(globalThis as any).FinalizationRegistry) {
 const deletetableRegistry = new (globalThis as any).FinalizationRegistry(
   (heldValue: Deletable) => {
     try {
-      console.log("gc!");
       heldValue.delete();
     } catch (e) {
       console.error(e);

--- a/packages/replicad/src/shapeHelpers.ts
+++ b/packages/replicad/src/shapeHelpers.ts
@@ -11,7 +11,7 @@ import {
   isShape3D,
   Shell,
 } from "./shapes";
-import { asPnt, makeAx3, makeAx2, Point, asVec } from "./geom";
+import { asPnt, makeAx3, makeAx2, Point, Vector } from "./geom";
 import { getOC } from "./oclib.js";
 import { localGC } from "./register.js";
 import { GeomAPI_PointsToBSpline } from "replicad-opencascadejs";
@@ -241,7 +241,7 @@ export const makeTangentArc = (
   const circleGeom = r(
     new oc.GC_MakeArcOfCircle_5(
       r(asPnt(startPoint)),
-      r(asVec(startTgt)),
+      new Vector(startTgt).wrapped,
       r(asPnt(endPoint))
     ).Value()
   );

--- a/packages/replicad/src/shapes.ts
+++ b/packages/replicad/src/shapes.ts
@@ -1,4 +1,4 @@
-import { WrappingObj, localGC } from "./register.js";
+import { WrappingObj, GCWithScope } from "./register.js";
 import { Vector, Point, Plane, PlaneName, asPnt } from "./geom.js";
 import { HASH_CODE_MAX } from "./constants.js";
 import { getOC } from "./oclib.js";
@@ -334,7 +334,7 @@ export class Shape<Type extends TopoDS_Shape> extends WrappingObj<Type> {
     lines: number[];
     edgeGroups: { start: number; count: number; edgeId: number }[];
   } {
-    const [r, gc] = localGC();
+    const r = GCWithScope();
     const recordedEdges = new Set();
     const lines: number[] = [];
     const edgeGroups: { start: number; count: number; edgeId: number }[] = [];
@@ -439,7 +439,6 @@ export class Shape<Type extends TopoDS_Shape> extends WrappingObj<Type> {
       done(edgeHash);
     }
 
-    gc();
     return { lines, edgeGroups };
   }
 
@@ -792,7 +791,7 @@ export class Face extends Shape<TopoDS_Face> {
     let u = 0;
     let v = 0;
 
-    const [r, gc] = localGC();
+    const r = GCWithScope();
 
     if (!locationVector) {
       const { uMin, uMax, vMin, vMax } = this.UVBounds;
@@ -824,7 +823,6 @@ export class Face extends Shape<TopoDS_Face> {
     props.Normal(u, v, p, vn);
 
     const normal = new Vector(vn);
-    gc();
     return normal;
   }
 

--- a/packages/replicad/src/shapes.ts
+++ b/packages/replicad/src/shapes.ts
@@ -1022,14 +1022,42 @@ export class _3DShape<Type extends TopoDS_Shape> extends Shape<Type> {
    * @category Shape Modifications
    */
   shell(
-    {
-      filter,
-      thickness,
-      keepFilter,
-    }: { filter: FaceFinder; thickness: number; keepFilter?: boolean },
+    config: { filter: FaceFinder; thickness: number },
+    tolerance?: number
+  ): Shape3D;
+  shell(
+    thickness: number,
+    finderFcn: (f: FaceFinder) => FaceFinder,
+    tolerance?: number
+  ): Shape3D;
+  shell(
+    thicknessOrConfig: { filter: FaceFinder; thickness: number } | number,
+    toleranceOrFinderFcn:
+      | null
+      | number
+      | ((f: FaceFinder) => FaceFinder) = null,
     tolerance = 1e-3
   ): Shape3D {
-    const filteredFaces = filter.find(this, { clean: !keepFilter });
+    const tol =
+      typeof toleranceOrFinderFcn === "number"
+        ? toleranceOrFinderFcn
+        : tolerance;
+    let filter;
+    let thickness;
+
+    if (typeof thicknessOrConfig === "number") {
+      thickness = thicknessOrConfig;
+      const ff = new FaceFinder();
+      filter =
+        typeof toleranceOrFinderFcn === "function"
+          ? toleranceOrFinderFcn(ff)
+          : ff;
+    } else {
+      thickness = thicknessOrConfig.thickness;
+      filter = thicknessOrConfig.filter;
+    }
+
+    const filteredFaces = filter.find(this);
     const facesToRemove = new this.oc.TopTools_ListOfShape_1();
 
     filteredFaces.forEach((face: Face) => {
@@ -1042,7 +1070,7 @@ export class _3DShape<Type extends TopoDS_Shape> extends Shape<Type> {
       this.wrapped,
       facesToRemove,
       -Math.abs(thickness),
-      tolerance,
+      tol,
       this.oc.BRepOffset_Mode.BRepOffset_Skin as any,
       false,
       false,
@@ -1110,13 +1138,24 @@ export class _3DShape<Type extends TopoDS_Shape> extends Shape<Type> {
    *
    * @category Shape Modifications
    */
-  fillet(radiusConfig: RadiusConfig): Shape3D {
+  fillet(
+    radiusConfig: RadiusConfig,
+    filter?: (e: EdgeFinder) => EdgeFinder
+  ): Shape3D {
     const filletBuilder = new this.oc.BRepFilletAPI_MakeFillet(
       this.wrapped,
       this.oc.ChFi3d_FilletShape.ChFi3d_Rational as any
     );
 
-    this._builderIter(radiusConfig, (r, e) => filletBuilder.Add_2(r, e));
+    let config = radiusConfig;
+    if (typeof radiusConfig === "number" && filter) {
+      config = {
+        radius: radiusConfig,
+        filter: filter(new EdgeFinder()),
+      };
+    }
+
+    this._builderIter(config, (r, e) => filletBuilder.Add_2(r, e));
 
     const newShape = cast(filletBuilder.Shape());
     filletBuilder.delete();
@@ -1141,10 +1180,20 @@ export class _3DShape<Type extends TopoDS_Shape> extends Shape<Type> {
    *
    * @category Shape Modifications
    */
-  chamfer(radiusConfig: RadiusConfig): Shape3D {
+  chamfer(
+    radiusConfig: RadiusConfig,
+    filter?: (e: EdgeFinder) => EdgeFinder
+  ): Shape3D {
     const chamferBuilder = new this.oc.BRepFilletAPI_MakeChamfer(this.wrapped);
 
-    this._builderIter(radiusConfig, (r, e) => chamferBuilder.Add_2(r, e));
+    let config = radiusConfig;
+    if (typeof radiusConfig === "number" && filter) {
+      config = {
+        radius: radiusConfig,
+        filter: filter(new EdgeFinder()),
+      };
+    }
+    this._builderIter(config, (r, e) => chamferBuilder.Add_2(r, e));
 
     const newShape = cast(chamferBuilder.Shape());
     chamferBuilder.delete();

--- a/packages/replicad/src/sketches/Sketch.ts
+++ b/packages/replicad/src/sketches/Sketch.ts
@@ -1,5 +1,5 @@
 import { Vector, Plane, Point } from "../geom.js";
-import { localGC, RegisteredObj } from "../register.js";
+import { localGC } from "../register.js";
 import { makeFace, makeNewFaceWithinFace } from "../shapeHelpers.js";
 import {
   basicFaceExtrusion,
@@ -23,7 +23,7 @@ import { SketchInterface } from "./lib.js";
  *
  * @category Sketching
  */
-export default class Sketch extends RegisteredObj implements SketchInterface {
+export default class Sketch implements SketchInterface {
   wire: Wire;
   /**
    * @ignore
@@ -46,7 +46,6 @@ export default class Sketch extends RegisteredObj implements SketchInterface {
       defaultDirection?: Point;
     } = {}
   ) {
-    super();
     this.wire = wire;
     this.defaultOrigin = defaultOrigin;
     this.defaultDirection = defaultDirection;
@@ -67,7 +66,6 @@ export default class Sketch extends RegisteredObj implements SketchInterface {
     this._defaultOrigin.delete();
     this._defaultDirection.delete();
     this.baseFace && this.baseFace.delete();
-    super.delete();
   }
 
   clone(): Sketch {

--- a/packages/replicad/tsconfig.json
+++ b/packages/replicad/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "target": "es2021",
+    "target": "es6",
     "module":"es2015",
     "strict": true,
     "sourceMap": true,

--- a/packages/replicad/tsconfig.json
+++ b/packages/replicad/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es2021",
     "module":"es2015",
     "strict": true,
     "sourceMap": true,


### PR DESCRIPTION
With ` FinalizationRegistry` being available (and also me learning about it), we can rely on the JS garbage collection to trigger deletion of the opencascade layer.

The public API (or at least the document part of it), should now all be automatically garbage collected, not need to explicitely `delete` vectors or finders (and no need to expose weird options related to the lifeftime of these objects).

The general strategy has been to use the `WrappingObj` class to manage wrapped, raw OCCT objects using the finalization registry.