### PR TITLE
Fix typo in Shape.repr

### DIFF
--- a/packages/replicad/src/shapes.ts
+++ b/packages/replicad/src/shapes.ts
@@ -544,7 +544,7 @@ export abstract class _1DShape<Type extends TopoDS_Shape> extends Shape<Type> {
   protected abstract _geomAdaptor(): CurveLike;
   get repr(): string {
     const { startPoint, endPoint } = this;
-    const retVal = `start: (${this.startPoint.repr}) end:(${this.endPoint.repr}}`;
+    const retVal = `start: (${this.startPoint.repr}) end:(${this.endPoint.repr})`;
     startPoint.delete();
     endPoint.delete();
     return retVal;


### PR DESCRIPTION
Without this fix repr returns something like `start: (x: 0, y: 0, z: 0) end:(x: 1, y: 0, z: -0.9}` - note the curly bracket at the end