### PR TITLE
Fix TypeScript signature of the emscripten module init function

### DIFF
--- a/packages/replicad-opencascadejs/src/replicad_single.d.ts
+++ b/packages/replicad-opencascadejs/src/replicad_single.d.ts
@@ -7097,6 +7097,6 @@ export type OpenCascadeInstance = {FS: typeof FS} & {
   Extrema_ExtAlgo: Extrema_ExtAlgo;
 };
 
-declare function init(): Promise<OpenCascadeInstance>;
+declare function init(module: any): Promise<OpenCascadeInstance>;
 
 export default init;


### PR DESCRIPTION
This fixes TypeScript problem described in issue #54.

The pach adds the missing argument to the init function. For simplicity, the type of the argument is set to `any`. Exact type could be imported from [@types/emscripten](https://www.npmjs.com/package/@types/emscripten). However, introducing new dependency is a serious thing, so I leave the decision to the maintainers of this awesome package.