### PR TITLE
Studio: Add title attributes to header buttons

### DIFF
--- a/packages/studio/src/workbench/EditorPane.jsx
+++ b/packages/studio/src/workbench/EditorPane.jsx
@@ -174,17 +174,17 @@ export const EditorButtons = observer(() => {
     <>
       {filePickerSupported && (
         <>
-          <HeaderButton onClick={toggleAutoload}>
+          <HeaderButton onClick={toggleAutoload} title="Toggle autoreload">
             <Reload />
           </HeaderButton>
           <Spacer />
         </>
       )}
 
-      <HeaderButton onClick={() => setShare(true)}>
+      <HeaderButton onClick={() => setShare(true)} title="Share">
         <Share />
       </HeaderButton>
-      <HeaderButton onClick={download}>
+      <HeaderButton onClick={download} title="Download">
         <Download />
       </HeaderButton>
       {share && <ShareDialog onClose={() => setShare(false)} />}

--- a/packages/studio/src/workbench/VisualizerPane.jsx
+++ b/packages/studio/src/workbench/VisualizerPane.jsx
@@ -44,7 +44,7 @@ export const VisualizerButtons = observer(() => {
         </>
       ) : null}
 
-      <HeaderButton onClick={() => store.ui.changeDownload(true)}>
+      <HeaderButton onClick={() => store.ui.changeDownload(true)} title="Download">
         <Download />
       </HeaderButton>
       {!store.ui.currentIsSVG && (
@@ -52,6 +52,7 @@ export const VisualizerButtons = observer(() => {
           solid={!store.ui.clip.disabled}
           small
           onClick={() => store.ui.clip.toggle()}
+          title="Clipping plane"
         >
           <Clipping />
         </HeaderButton>
@@ -61,6 +62,7 @@ export const VisualizerButtons = observer(() => {
           solid={store.ui.enableParams}
           small
           onClick={() => store.ui.changeEnableParams(!store.ui.enableParams)}
+          title="Parameters"
         >
           <Configure />
         </HeaderButton>

--- a/packages/studio/src/workbench/panes.jsx
+++ b/packages/studio/src/workbench/panes.jsx
@@ -99,6 +99,7 @@ export const Pane = ({ children, buttons, aboveOthers }) => {
         <HeaderButton
           solid={fullscreen}
           onClick={() => setFullscreen(!fullscreen)}
+          title="Fullscreen"
         >
           <Fullscreen />
         </HeaderButton>


### PR DESCRIPTION
Adds title attributes for header buttons.

I think the icons can be pretty unclear, especially for new users (ex: when sharing parameterized models with other people).