### PR TITLE
Studio: More compact param panel

### DIFF
--- a/packages/studio/src/components/FloatingInfo.jsx
+++ b/packages/studio/src/components/FloatingInfo.jsx
@@ -9,7 +9,8 @@ export const InfoTopRight = styled.div`
   max-width: 300px;
   padding: 10px;
   border-radius: 10px;
-  height: auto;
+  max-height: calc(100% - 5em);
+  overflow-y: auto;
 
   ${(props) =>
     props.noBg ? "" : `background-color: white; border: 1px solid lightgrey;`}

--- a/packages/studio/src/visualiser/editor/ParamsEditor.jsx
+++ b/packages/studio/src/visualiser/editor/ParamsEditor.jsx
@@ -46,7 +46,6 @@ export default observer(function ParamsEditor({
       fill
       flat
       hideCopyButton
-      oneLineLabels
       titleBar={false}
       hidden={hidden}
       theme={{
@@ -65,6 +64,9 @@ export default observer(function ParamsEditor({
 
           vivid1: "red",
         },
+        sizes: {
+          controlWidth: "80px"
+        }
       }}
     />
   );


### PR DESCRIPTION
A few changes for models with more parameters:

* disable one line labels, so that labels and inputs are on the same line
* reduce width of input control
* add vertical scrolling when parameter panel is larger than screen height

## Before
![image](https://github.com/sgenoud/replicad/assets/242008/6dcc8ed2-ee7b-47b0-8f67-cab89dc11ac6)

## After
![image](https://github.com/sgenoud/replicad/assets/242008/9268c77d-9153-4ce0-9bbb-81b9b30e69d3)

## Overflow
![image](https://github.com/sgenoud/replicad/assets/242008/53283303-2175-4f56-85cc-04a7d6db09aa)

Related: #128 