### PR TITLE
Studio: Open parameters panel by default

### DIFF
--- a/packages/studio/src/visualiser/editor/ui-state.js
+++ b/packages/studio/src/visualiser/editor/ui-state.js
@@ -44,7 +44,7 @@ export default types.optional(
       highlightedEdgeIndex: types.maybe(types.maybeNull(types.number)),
       clip: ClipConfig,
       showDownload: types.optional(types.boolean, false),
-      enableParams: types.optional(types.boolean, false),
+      enableParams: types.optional(types.boolean, true),
     })
     .views((self) => ({
       get singleShape() {


### PR DESCRIPTION
I don't know what the decision making process for this was, so feel free to close!

This change defaults the parameters panel to open, if parameters are available.

This fixes #103, and I think it's more usable in general (personally).