### PR TITLE
Studio share: More compact parameter panel

### DIFF
--- a/packages/studio/src/components/StandardUI.jsx
+++ b/packages/studio/src/components/StandardUI.jsx
@@ -53,9 +53,13 @@ const AutoConfig = ({ updateParams, defaultParams, hidden }) => {
           elevation3: "var(--color-primary)", // bg color of the inputs
 
           highlight1: "white",
-          highlight2: "var(--color-primary-light)",
+          highlight2: "var(--color-secondary-light)",
           highlight3: "lightgrey",
         },
+        sizes: {
+          rootWidth: "250px",
+          controlWidth: "80px"
+        }
       }}
     />
   );


### PR DESCRIPTION
This duplicates the change from #130 to the share display as well, and also increases the color contrast for labels and input values:

## Before:
![image](https://github.com/sgenoud/replicad/assets/242008/886bb0a3-0f8d-4241-be85-d940088a6069)

## After:
![image](https://github.com/sgenoud/replicad/assets/242008/46a9f8e0-1aea-484d-83df-b18e23a1b20b)
