### PR TITLE
Studio share: add `params` option to expand parameters panel by default

### DIFF
--- a/packages/studio/src/LinkWidget.jsx
+++ b/packages/studio/src/LinkWidget.jsx
@@ -220,6 +220,7 @@ export function MakeLink() {
   const [disableAutoPosition, setDisableAutoPosition] = useState(false);
   const [disableDamping, setDisableDamping] = useState(false);
   const [hideGrid, setHideGrid] = useState(false);
+  const [expandParametersPanel, setExpandParametersPanel] = useState(false);
 
   let link = null;
   if (inputVal) {
@@ -229,6 +230,7 @@ export function MakeLink() {
       url.searchParams.set("disable-auto-position", "true");
     disableDamping && url.searchParams.set("disable-damping", "true");
     hideGrid && url.searchParams.set("hide-grid", "true");
+    expandParametersPanel && url.searchParams.set("params", "true");
     link = url.toString();
   }
 
@@ -275,6 +277,15 @@ export function MakeLink() {
               onChange={(e) => setHideGrid(!e.target.checked)}
             />
             <label htmlFor="hide-grid">Grid</label>
+          </span>
+          <span>
+            <input
+              id="expand-params"
+              type="checkbox"
+              checked={expandParametersPanel}
+              onChange={(e) => setExpandParametersPanel(e.target.checked)}
+            />
+            <label htmlFor="expand-params">Parameters panel open</label>
           </span>
         </Options>
 

--- a/packages/studio/src/LinkWidget.jsx
+++ b/packages/studio/src/LinkWidget.jsx
@@ -146,6 +146,7 @@ export default function LinkWidget() {
         disableDamping={
           searchParams.get("disable-damping")?.toLowerCase() === "true"
         }
+        showParams={searchParams.get("params")?.toLowerCase() === "true"}
         onSave={(format) => saveShape("defaultShape", format)}
         canSave={geometryHasBeenComputed}
       />

--- a/packages/studio/src/components/StandardUI.jsx
+++ b/packages/studio/src/components/StandardUI.jsx
@@ -21,7 +21,7 @@ const LoadingInfo = styled(InfoBottomLeft)`
   color: var(--color-primary-light);
 `;
 
-const AutoConfig = ({ updateParams, defaultParams, hidden }) => {
+const AutoConfig = ({ updateParams, defaultParams, hidden, collapsed}) => {
   const [params] = useControls(() => defaultParams);
   const paramsUpdater = useRef(updateParams);
 
@@ -43,8 +43,7 @@ const AutoConfig = ({ updateParams, defaultParams, hidden }) => {
   return (
     <Leva
       hideCopyButton
-      oneLineLabels
-      collapsed
+      collapsed={collapsed}
       hidden={hidden}
       theme={{
         colors: {
@@ -82,6 +81,7 @@ export default function StandardUI({
   updateParams,
   disableAutoPosition,
   disableDamping,
+  showParams,
   hideGrid,
   onSave,
   canSave,
@@ -107,6 +107,7 @@ export default function StandardUI({
       {defaultParams && (
         <AutoConfig
           hidden={niceViewer}
+          collapsed={!showParams}
           defaultParams={defaultParams}
           updateParams={updateParams}
         />


### PR DESCRIPTION
Fix for #103

The goal of this PR is to allow the parameter panel to be open by default when sharing links for projects where the configuration is the primary use case.

Adds a `params` boolean query string parameter that changes the leva `collapsed` property.