### PR TITLE
Studio share: Share via zipped code in URL

### DIFF
--- a/packages/studio/src/App.jsx
+++ b/packages/studio/src/App.jsx
@@ -31,6 +31,9 @@ export default function App() {
         <Route exact path="/share">
           <MakeLink />
         </Route>
+        <Route path="/share/code">
+          <LinkWidget />
+        </Route>
         <Route path="/share/:shapeURL">
           <LinkWidget />
         </Route>

--- a/packages/studio/src/LinkWidget.jsx
+++ b/packages/studio/src/LinkWidget.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect, useCallback } from "react";
-import JSZip from 'jszip'
+
 
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
@@ -7,6 +7,7 @@ import axios from "axios";
 import { ellipsis } from "polished";
 
 import builderAPI from "./utils/builderAPI";
+import loadCode from "./utils/loadCode"
 import saveShape from "./utils/saveShape";
 
 import { Button } from "./components/Button.jsx";
@@ -36,12 +37,6 @@ const AdditionalInfo = styled.div`
 
 const TEST_URL =
   "https%3A%2F%2Fraw.githubusercontent.com%2Fsgenoud%2Freplicad%2Fmain%2Fpackages%2Freplicad-docs%2Fexamples%2FsimpleVase.js";
-
-const loadCode = async (rawCode) => {
-  const content = decodeURIComponent(rawCode);
-  const zip = await new JSZip().loadAsync(content, { base64: true });
-  return await zip?.file("code.js")?.async("string");
-};
 
 export default function LinkWidget() {
   const { shapeURL } = useParams();

--- a/packages/studio/src/components/StandardUI.jsx
+++ b/packages/studio/src/components/StandardUI.jsx
@@ -93,7 +93,7 @@ export default function StandardUI({
 
   return (
     <>
-      {computedShapes.length ? (
+      {computedShapes?.length ? (
         <Viewer
           shapes={computedShapes}
           hideGrid={hideGrid}
@@ -142,7 +142,7 @@ export default function StandardUI({
           </ContextButton>
         )}
       </InfoMenu>
-      {isLoading && !!computedShapes.length && (
+      {isLoading && !!computedShapes?.length && (
         <LoadingInfo noBg hide={niceViewer}>
           <Loading size="3em" />
         </LoadingInfo>

--- a/packages/studio/src/utils/downloadCode.js
+++ b/packages/studio/src/utils/downloadCode.js
@@ -1,0 +1,16 @@
+import { fileSave } from 'browser-fs-access'
+
+export default (code, fileName) => {
+  fileName = fileName ?? 'replicad-script'
+  return fileSave(
+    new Blob([code], {
+      type: "application/javascript",
+    }),
+    {
+      id: "save-js",
+      fileName: `${fileName}.js`,
+      description: "JS replicad script of the current geometry",
+      extensions: [".js"],
+    }
+  );
+};

--- a/packages/studio/src/utils/loadCode.js
+++ b/packages/studio/src/utils/loadCode.js
@@ -1,0 +1,7 @@
+import JSZip from 'jszip'
+
+export default async (rawCode) => {
+  const content = decodeURIComponent(rawCode);
+  const zip = await new JSZip().loadAsync(content, { base64: true });
+  return await zip?.file("code.js")?.async("string");
+};

--- a/packages/studio/src/visualiser/editor/codeInit.js
+++ b/packages/studio/src/visualiser/editor/codeInit.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import JSZip from "jszip";
+import loadCode from "../../utils/loadCode"
 
 const DEFAULT_SCRIPT = `
 const { draw } = replicad;
@@ -40,12 +41,6 @@ const loadFromUrl = async (url) => {
 
   const response = await axios.get(codeUrl);
   return response.data;
-};
-
-const loadCode = async (rawCode) => {
-  const content = decodeURIComponent(rawCode);
-  const zip = await new JSZip().loadAsync(content, { base64: true });
-  return await zip?.file("code.js")?.async("string");
 };
 
 export const exportCode = async (rawCode) => {

--- a/packages/studio/src/workbench/EditorPane.jsx
+++ b/packages/studio/src/workbench/EditorPane.jsx
@@ -2,13 +2,13 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import { observer } from "mobx-react";
 import Editor from "@monaco-editor/react";
-import { fileSave } from "browser-fs-access";
 
 import replicadTypes from "../../node_modules/replicad/dist/replicad.d.ts?raw";
 
 import Splitter, { GutterTheme, SplitDirection } from "@devbookhq/splitter";
 
 import useEditorStore from "../visualiser/editor/useEditorStore";
+import downloadCode from '../utils/downloadCode'
 import { HeaderButton } from "./panes";
 import Download from "../icons/Download";
 import Share from "../icons/Share";
@@ -151,21 +151,8 @@ export const EditorButtons = observer(() => {
   const toggleAutoload = useAutoload();
 
   const download = () => {
-    return fileSave(
-      new Blob([store.code.current], {
-        type: "application/javascript",
-      }),
-      {
-        id: "save-js",
-        fileName: `${
-          store.currentMesh.length === 1
-            ? store.currentMesh[0]?.name
-            : "replicad-script"
-        }.js`,
-        description: "JS replicad script of the current geometry",
-        extensions: [".js"],
-      }
-    );
+    const shapeName = store.currentMesh.length === 1 ? store.currentMesh[0]?.name : null
+    return downloadCode(store.code.current, shapeName)
   };
 
   const filePickerSupported = window.showOpenFilePicker !== undefined;


### PR DESCRIPTION
This PR allows sharing projects with project code zipped in the URL, similar to the studio workbench.

`https://replicad.xyz/share/code#code=....`

Instead of using a query parameter, I'm using the location hash, which has a couple of advantages:

* The entire project code won't be passed with the request to the server
* Project size not limited by web host's query parameter limits

This is the same change (for the same reasons) to cascade studio here, also hosted on github pages:
https://github.com/zalo/CascadeStudio/pull/121

Hash parameters like this could be used for the other share flags (`disable-damping`, `hide-grid` etc), but since they're short, they're unlikely to hit any of these limits.

This share URL isn't currently exposed anywhere, since it requires loading the project code (in order to zip it).

I think it could be added to the share panel in the workbench, since that's already zipping the project code, but it would probably want to know about the additional share parameters, and the share URL etc.