### PR TITLE
Fix mirror types

### DIFF
--- a/packages/replicad/src/geomHelpers.ts
+++ b/packages/replicad/src/geomHelpers.ts
@@ -65,8 +65,8 @@ export function translate(shape: TopoDS_Shape, vector: Point): TopoDS_Shape {
 
 export function mirror(
   shape: TopoDS_Shape,
-  inputPlane: Plane | PlaneName | Point,
-  origin: Point
+  inputPlane?: Plane | PlaneName | Point,
+  origin?: Point
 ): TopoDS_Shape {
   const transformation = new Transformation();
   transformation.mirror(inputPlane, origin);

--- a/packages/replicad/src/shapes.ts
+++ b/packages/replicad/src/shapes.ts
@@ -261,7 +261,7 @@ export class Shape<Type extends TopoDS_Shape> extends WrappingObj<Type> {
    *
    * @category Shape Transformations
    */
-  mirror(inputPlane: Plane | PlaneName | Point, origin: Point): this {
+  mirror(inputPlane?: Plane | PlaneName | Point, origin?: Point): this {
     const newShape = cast(mirror(this.wrapped, inputPlane, origin));
     this.delete();
 


### PR DESCRIPTION
Hi, thanks for replicad. Made a few models now. Appreciate the workbench, code interface, and documentation. Am coming from OpenSCAD, so I love the fillets and such. Cheers :purple_heart: 

Anyways, here's a very basic pull request to fix the TypeScript types of `.mirror()`.

Is there a way setup to test the TypeScript types?