### PR TITLE
Add defaultName for saving .js or .zip

### DIFF
--- a/packages/studio/src/builder.worker.js
+++ b/packages/studio/src/builder.worker.js
@@ -55,11 +55,33 @@ const extractDefaultParamsFromCode = async (code) => {
 
   const editedText = `
 ${code}
-let dp = null
 try {
-  dp = defaultParams;
-} catch (e) { }
-return dp
+  return defaultParams;
+} catch (e) {
+  return null;
+}
+  `;
+
+  try {
+    return runInContext(editedText, {});
+  } catch (e) {
+    return {};
+  }
+};
+
+const extractDefaultNameFromCode = async (code) => {
+  if (code.match(/^\s*export\s+/m)) {
+    const module = await buildModuleEvaluator(code);
+    return module.defaultName || null;
+  }
+
+  const editedText = `
+${code}
+try {
+  return defaultName;
+} catch (e) {
+  return null;
+}
   `;
 
   try {
@@ -216,6 +238,7 @@ const service = {
   ready: () => OC.then(() => true),
   buildShapesFromCode,
   extractDefaultParamsFromCode,
+  extractDefaultNameFromCode,
   exportShape,
   edgeInfo,
   faceInfo,

--- a/packages/studio/src/utils/downloadCode.js
+++ b/packages/studio/src/utils/downloadCode.js
@@ -1,7 +1,10 @@
-import { fileSave } from 'browser-fs-access'
+import { fileSave } from 'browser-fs-access';
+import builderAPI from './builderAPI';
 
-export default (code, fileName) => {
-  fileName = fileName ?? 'replicad-script'
+export default async (code, fileName) => {
+  fileName = fileName
+    ?? await builderAPI.extractDefaultNameFromCode(code)
+    ?? 'replicad-script'
   return fileSave(
     new Blob([code], {
       type: "application/javascript",

--- a/packages/studio/src/utils/saveShape.js
+++ b/packages/studio/src/utils/saveShape.js
@@ -11,7 +11,7 @@ const mapExt = (ext) => {
   return ext;
 };
 
-export default async function saveShapes(shapeId, fileType = "stl") {
+export default async function saveShapes(shapeId, fileType = "stl", code) {
   const shapes = await builderAPI.exportShape(fileType, shapeId);
   if (shapes.length === 1) {
     const { blob, name } = shapes[0];
@@ -25,6 +25,7 @@ export default async function saveShapes(shapeId, fileType = "stl") {
     return;
   }
 
+  const defaultName = await builderAPI.extractDefaultNameFromCode(code);
   const zip = new JSZip();
   shapes.forEach((shape, i) => {
     zip.file(`${shape.name || `shape-${i}`}.${mapExt(fileType)}`, shape.blob);
@@ -33,7 +34,7 @@ export default async function saveShapes(shapeId, fileType = "stl") {
   await fileSave(zipBlob, {
     id: "exports",
     description: "Save zip",
-    fileName: `${shapeId}.zip`,
+    fileName: `${defaultName ?? shapeId}.zip`,
     extensions: [".zip"],
   });
 }

--- a/packages/studio/src/visualiser/editor/DownloadDialog.jsx
+++ b/packages/studio/src/visualiser/editor/DownloadDialog.jsx
@@ -78,7 +78,7 @@ export default function DownloadDialog({ onClose }) {
       );
     } else {
       try {
-        await saveShape("defaultShape", saveMode);
+        await saveShape("defaultShape", saveMode, store.code.current);
       } catch (e) {
         console.error(e);
       } finally {


### PR DESCRIPTION
Allows exporting `defaultName` which will be used when saving `.js` or `.zip` files

Fixes #177 