### PR TITLE
Add dark mode support for visualizer canvas

### DIFF
--- a/packages/studio/src/GlobalStyles.jsx
+++ b/packages/studio/src/GlobalStyles.jsx
@@ -58,6 +58,13 @@ export default createGlobalStyle`
     --bg-color: #f2f3f4;
   }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #1e1e1e;
+  }
+}
+
+
 a {
     color: var(--color-primary);
 }


### PR DESCRIPTION
My OS is set to use dark mode and Monaco editor has dark background, to see the logs the devtools is also in dark mode.
The only part not respecting the preferred setting is the threejs canvas.