### PR TITLE
Increase text contrast in dark mode, fix usage of light mode colors

### DIFF
--- a/packages/studio/src/GlobalStyles.jsx
+++ b/packages/studio/src/GlobalStyles.jsx
@@ -59,10 +59,16 @@ export default createGlobalStyle`
     --color-secondary-light: #f2e0de;
     --color-secondary-dark: #c0695d;
     --bg-color: #f2f3f4;
+    
+    --color-header-primary: rgb(90, 130, 150);
+    --color-header-secondary: rgb(60, 90, 110);
   }
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --color-primary: rgb(122, 176, 204);
+    --color-primary-light: rgb(60, 90, 110);
+    --color-primary-dark: rgb(170, 190, 200);
     --bg-color: #1e1e1e;
     --bg-color-secondary: #2e2e2e;
     --text-color: #f2f2f2;

--- a/packages/studio/src/Welcome.jsx
+++ b/packages/studio/src/Welcome.jsx
@@ -19,8 +19,8 @@ const Hero = styled.div`
   background: var(--color-primary-dark);
   background: linear-gradient(
     351deg,
-    var(--color-primary-dark) 0%,
-    var(--color-primary) 95%
+    var(--color-header-secondary) 0%,
+    var(--color-header-primary) 95%
   );
   color: white;
 `;

--- a/packages/studio/src/components/Button.jsx
+++ b/packages/studio/src/components/Button.jsx
@@ -4,7 +4,6 @@ export const Button = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  border: none;
   border-radius: 0.2em;
   background-color: transparent;
   border: 1px solid transparent;

--- a/packages/studio/src/components/Dialog.jsx
+++ b/packages/studio/src/components/Dialog.jsx
@@ -54,7 +54,7 @@ const DialogBox = styled.div`
   flex-direction: column;
 
   background: var(--bg-color);
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-primary);
   box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
   outline: none;
 

--- a/packages/studio/src/components/FloatingInfo.jsx
+++ b/packages/studio/src/components/FloatingInfo.jsx
@@ -15,7 +15,7 @@ export const InfoTopRight = styled.div`
   ${(props) =>
     props.noBg
       ? ""
-      : `background-color: var(--bg-color); border: 1px solid lightgrey;`}
+      : `background-color: var(--bg-color); border: 1px solid var(--color-primary-light);`}
 `;
 
 export const InfoBottomLeft = styled(InfoTopRight)`

--- a/packages/studio/src/components/LinkEditor.jsx
+++ b/packages/studio/src/components/LinkEditor.jsx
@@ -16,6 +16,9 @@ const Url = styled.a`
 
 const Divider = styled.hr`
   margin: 3em;
+  height: 1px;
+  border: 0;
+  border-bottom: 1px solid var(--color-primary-light);
 `;
 
 const Options = styled.div`

--- a/packages/studio/src/visualiser/editor/ClippingParams.jsx
+++ b/packages/studio/src/visualiser/editor/ClippingParams.jsx
@@ -30,7 +30,8 @@ const NumberEditor = React.memo(function NumberEditor({
     height: 24px;
     line-height: 1.15;
     border-radius: 3px;
-
+    background-color: var(--bg-color-secondary);
+    
     &:hover {
       box-shadow: inset 0 0 0 1px var(--color-primary);
     }

--- a/packages/studio/src/workbench/panes.jsx
+++ b/packages/studio/src/workbench/panes.jsx
@@ -64,7 +64,7 @@ export const PaneHeader = styled.div`
   flex: 0 0 var(--pane-header-height);
   justify-content: flex-end;
   height: var(--pane-header-height);
-  background-color: var(--color-primary-dark);
+  background-color: var(--color-header-secondary);
   padding: 0.2em 2rem;
   box-shadow: rgb(0 0 0 / 35%) 0px -6px 12px 3px inset;
 


### PR DESCRIPTION
There are a few places in dark mode that used either very low contrast (especially for text/forms), and some that ended up being very high contrast (because they were using colors from light mode).

Some of these changes do effect light mode as well.
There are some unintended changes to related elements (like buttons), but I think it's an overall improvement without delving too deep.

The SVG viewer component has some issues in dark mode as well, but I'll open a separate issue for those, since the solution is less obvious to me

## Params panel

Dark mode before/after (clipping field _is_ populated in before image)

![Dark mode before](https://github.com/user-attachments/assets/f16a9968-04da-40ab-988b-b899eabc59e3)
![Dark mode after](https://github.com/user-attachments/assets/d03358ca-7fa0-4060-9a38-c4f94878e11d)

Light mode before/after (border slightly darker)
![Light mode before](https://github.com/user-attachments/assets/860a7aa7-a9bb-4017-969b-273cc55b0c01)
![Light mode after](https://github.com/user-attachments/assets/d05b8333-14da-4820-8674-3d738aab38c1)

## Share panel

Dark mode before/after

![Dark mode before](https://github.com/user-attachments/assets/d1ac9553-94d9-4f87-8d3d-a3eee8f202a5)
![Dark mode after](https://github.com/user-attachments/assets/00f6ab34-0b52-4a8a-b206-b62e8bebae31)

Light mode before/after

![Light mode before](https://github.com/user-attachments/assets/e0d0e225-6c27-4d8a-9c0d-1bc623b9e498)
![Light mode after](https://github.com/user-attachments/assets/44b9384d-c8d1-467c-8943-6023527a868e)

