### PR TITLE
Increase leva field width

### DIFF
--- a/packages/studio/src/components/StandardUI.jsx
+++ b/packages/studio/src/components/StandardUI.jsx
@@ -62,8 +62,8 @@ const AutoConfig = ({ updateParams, defaultParams, hidden, collapsed }) => {
           vivid1: "red",
         },
         sizes: {
-          rootWidth: "250px",
-          controlWidth: "80px",
+          rootWidth: null,
+          controlWidth: "150px",
         },
       }}
     />

--- a/packages/studio/src/visualiser/editor/ParamsEditor.jsx
+++ b/packages/studio/src/visualiser/editor/ParamsEditor.jsx
@@ -65,7 +65,7 @@ export default observer(function ParamsEditor({
           vivid1: "red",
         },
         sizes: {
-          controlWidth: "80px",
+          controlWidth: "150px",
         },
       }}
     />


### PR DESCRIPTION
Increases the width of param fields to accommodate  some of leva's bulkier items:

## Before (width: 80px)
![image](https://github.com/user-attachments/assets/d7fa56f9-a437-463a-8c20-29573d164a2a)

## After (width: 150px)
![image](https://github.com/user-attachments/assets/b6dfe597-4ece-4bf7-8eb3-75a76b57e2fb)

For the share view, I've also set `rootWidth` to null, to match the autosizing behavior in the workbench (which uses a different wrapping element without a width), rather than the 250px fixed width. This ends up slightly smaller than the default share view if labels are short (<9-ish characters)
