### PR TITLE
Add small debounce before rendering to editor

### DIFF
--- a/packages/studio/src/workbench/EditorPane.jsx
+++ b/packages/studio/src/workbench/EditorPane.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import debounce from "debounce";
 import styled from "styled-components";
 import { observer } from "mobx-react";
 import Editor from "@monaco-editor/react";
@@ -100,9 +101,9 @@ export default observer(function EditorPane() {
           defaultValue={store.code.current}
           theme="vs-dark"
           height="100%"
-          onChange={(e) => {
+          onChange={debounce((e) => {
             store.code.update(e, true);
-          }}
+          }, 300)}
           onMount={handleEditorDidMount}
           options={{
             automaticLayout: true,


### PR DESCRIPTION
Adds a small (300ms) debounce to the onChange event in the editor.

Immediately rendering on change often causes syntax or other errors (that are corrected with later typing), and on slower-to-render projects can "tie up" a rendering cycle until rendering completes and new changes can take effect.
