### PR TITLE
Add replicad-script to add types sepcific to replicad .js/.ts files

### DIFF
--- a/packages/replicad-script/.gitignore
+++ b/packages/replicad-script/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+yarn-error.log
+dist

--- a/packages/replicad-script/LICENSE
+++ b/packages/replicad-script/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2023 QuaroTech Sàrl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/replicad-script/README.md
+++ b/packages/replicad-script/README.md
@@ -1,0 +1,139 @@
+# `replicad`
+
+The library to build browser based 3D models with code.
+
+## How to play with it
+
+I am still working on making an accessible toolchain for replicad, so for now
+you can play with my [online
+"visualiser"](https://studio.replicad.xyz/visualiser).
+
+Write in a local file, select it in the tool and it should build your model.
+There is still a lot of work to make this intuitive, but you can play with the
+examples below. Note that if you use Chrome the model is recomputed as you
+change your local file.
+
+You need to write a "main" function that receives the complete `replicad`
+library.
+
+## Examples
+
+Here are some basic examples of things you can do with replicad.
+
+#### A simple example
+
+```js
+const main = ({ Sketcher }) => {
+  const base = new Sketcher("XZ")
+    .hLine(-25)
+    .halfEllipse(0, 40, 5, true)
+    .hLine(25)
+    .close()
+    .revolve([0, 0, 1]);
+
+  const hole = new Sketcher()
+    .quadraticBezierCurveTo([0, 20], [20, 30])
+    .closeWithMirror()
+    .extrude(40)
+    .translateY(-12);
+
+  return base.cut(hole);
+};
+```
+
+#### The open cascade bottle
+
+```js
+const defaultParams = {
+  width: 50,
+  height: 70,
+  thickness: 30,
+};
+
+const main = (
+  { Sketcher, FaceSketcher, localGC, makeCylinder, makeOffset, FaceFinder },
+  { width: myWidth, height: myHeight, thickness: myThickness }
+) => {
+  let shape = new Sketcher()
+    .movePointerTo([-myWidth / 2, 0])
+    .vLine(-myThickness / 4)
+    .threePointsArc(myWidth, 0, myWidth / 2, -myThickness / 4)
+    .vLine(myThickness / 4)
+    .closeWithMirror()
+    .extrude(myHeight)
+    .fillet(myThickness / 12);
+
+  const myNeckRadius = myThickness / 4;
+  const myNeckHeight = myHeight / 10;
+  const neck = makeCylinder(
+    myNeckRadius,
+    myNeckHeight,
+    [0, 0, myHeight],
+    [0, 0, 1]
+  );
+
+  shape = shape.fuse(neck);
+
+  shape = shape.shell({
+    filter: new FaceFinder().inPlane("XY", [0, 0, myHeight + myNeckHeight]),
+    thickness: myThickness / 50,
+  });
+
+  const [r, gc] = localGC();
+
+  const neckFace = r(
+    new FaceFinder()
+      .containsPoint([0, myNeckRadius, myHeight])
+      .ofSurfaceType("CYLINDRE")
+      .find(shape.clone(), { unique: true })
+  );
+
+  const bottomThreadFace = r(
+    r(makeOffset(neckFace, -0.01 * myNeckRadius)).faces[0]
+  );
+  const baseThreadSketch = new FaceSketcher(bottomThreadFace)
+    .movePointerTo([0, 0.25])
+    .halfEllipse(2, 0.5, 0.1)
+    .close();
+
+  const topThreadFace = r(
+    r(makeOffset(neckFace, 0.05 * myNeckRadius)).faces[0]
+  );
+  const topThreadSketch = new FaceSketcher(topThreadFace)
+    .movePointerTo([0, 0.25])
+    .halfEllipse(2, 0.5, 0.05)
+    .close();
+
+  const thread = baseThreadSketch.loftWith(topThreadSketch);
+  gc();
+
+  return shape.fuse(thread);
+};
+```
+
+## Making in work in an application
+
+You will need to load opencascadejs separately (you can use
+`replicad-opencascadejs` to only have the method necessary for replicad). You
+then need to inject it in `replicad` with the function:
+
+`setOC(oc)`
+
+Once this is done you can use `replicad` to draw your shapes.
+
+To export your shape, you can either use the `STL` or `STEP` save functions, or
+get the mesh and use it with three (or another 3d viewer library).
+
+Ideally the computation should be done in a worker.
+
+This all needs a bunch of helper, this should come soon(-ish)
+
+## License
+
+Copyright (C) 2021 QuaroTech Sàrl
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/packages/replicad-script/package.json
+++ b/packages/replicad-script/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "replicad-script",
+  "version": "0.17.4",
+  "description": "The library to build browser based 3D models with code",
+  "keywords": [
+    "cad",
+    "opencascadejs",
+    "brep",
+    "STEP",
+    "STL"
+  ],
+  "author": "Steve Genoud <steve@sgenoud.com>",
+  "homepage": "https://replicad.xyz",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/replicad-script.cjs",
+  "module": "./dist/replicad-script.js",
+  "types": "./dist/replicad-script.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/replicad-script.js",
+      "require": "./dist/replicad-script.umd.cjs"
+    }
+  },
+  "directories": {
+    "src": "src",
+    "test": "__tests__"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "start": "NO_TYPES=true vite build --watch",
+    "build-doc": "typedoc --exclude \"../replicad-opencascadejs/*\" --out docs --theme default src",
+    "build-docss": "typedoc --help",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.2.0",
+    "@typescript-eslint/parser": "^5.4.0",
+    "eslint": "^8.1.0",
+    "replicad": "^0.17.4",
+    "rollup": "3.28.0",
+    "rollup-plugin-ts": "3.4.4",
+    "typedoc": "^0.24.8",
+    "typescript": "^5.1.6",
+    "vite": "^4.0.4",
+    "vite-plugin-dts": "^3.5.2",
+    "vitest": "^0.28.3"
+  },
+  "dependencies": {}
+}

--- a/packages/replicad-script/src/replicad-script.ts
+++ b/packages/replicad-script/src/replicad-script.ts
@@ -1,0 +1,17 @@
+import * as _replicad from "replicad";
+
+export type ShapeConfig = {
+  shape: _replicad.AnyShape;
+  name?: string;
+  color?: string;
+  opacity?: number;
+};
+
+export type ShapesConfig =
+  | _replicad.AnyShape
+  | ShapeConfig
+  | (_replicad.AnyShape | ShapeConfig)[];
+  
+declare global {
+  export const replicad: typeof _replicad;
+};

--- a/packages/replicad-script/tsconfig.json
+++ b/packages/replicad-script/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "es6",
+    "module": "es2015",
+    "strict": true,
+    "lib": ["es2022", "dom"],
+    "preserveSymlinks": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["./src"]
+}

--- a/packages/replicad-script/vite.config.js
+++ b/packages/replicad-script/vite.config.js
@@ -1,0 +1,22 @@
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/replicad-script.ts"),
+      name: "replicad-script",
+      fileName: "replicad-script",
+      formats: ["es", "umd", "cjs"],
+    },
+    sourcemap: true,
+    minify: false,
+  },
+  plugins: [
+    dts(),
+  ],
+  test: {
+    setupFiles: ["./__tests__/setup.ts"],
+  },
+});


### PR DESCRIPTION
I've added some types for use replicad scripts.

e.g.
```typescript
import type {
  ShapesConfig,
} from "replicad"

// doesn't error
const {
  drawCircle,
  drawRectangle,
} = replicad

// ShapesConfig ensures the exported types are correct 
export default function main(params: typeof defaultParams): ShapesConfig {
  
}
```