### PR TITLE
Add option for 2D offset operation to specify the type of line join (round, bevel, miter)

### DIFF
--- a/packages/replicad/src/draw.ts
+++ b/packages/replicad/src/draw.ts
@@ -31,7 +31,7 @@ import { lookFromPlane, ProjectionCamera } from "./projection/ProjectionCamera";
 import type { ProjectionPlane } from "./projection/ProjectionCamera";
 import { makeProjectedEdges } from "./projection/makeProjectedEdges";
 
-import offset from "./blueprints/offset";
+import offset, { Offset2DConfig } from "./blueprints/offset";
 import { CornerFinder } from "./finders/cornerFinder";
 import { fillet2D, chamfer2D } from "./blueprints/customCorners";
 import { edgeToCurve } from "./curves";
@@ -175,8 +175,8 @@ export class Drawing implements DrawingInterface {
     return this.innerShape?.toSVGPaths() || [];
   }
 
-  offset(distance: number): Drawing {
-    return new Drawing(offset(this.innerShape, distance));
+  offset(distance: number, offsetConfig: Offset2DConfig = {}): Drawing {
+    return new Drawing(offset(this.innerShape, distance, offsetConfig));
   }
 
   approximate(

--- a/packages/replicad/src/lib2d/definitions.ts
+++ b/packages/replicad/src/lib2d/definitions.ts
@@ -3,3 +3,13 @@ export type Point2D = [number, number];
 export function isPoint2D(point: unknown): point is Point2D {
   return Array.isArray(point) && point.length === 2;
 }
+
+export type Matrix2X2 = [[number, number], [number, number]];
+
+export function isMatrix2X2(matrix: unknown): matrix is Matrix2X2 {
+  return (
+    Array.isArray(matrix) &&
+    matrix.length === 2 &&
+    matrix.every((row) => Array.isArray(row) && row.length === 2)
+  );
+}

--- a/packages/replicad/src/lib2d/vectorOperations.ts
+++ b/packages/replicad/src/lib2d/vectorOperations.ts
@@ -1,4 +1,4 @@
-import { Point2D } from "./definitions";
+import { Matrix2X2, Point2D } from "./definitions";
 
 export const samePoint = (
   [x0, y0]: Point2D,
@@ -91,4 +91,8 @@ export const cartesianToPolar = ([x, y]: Point2D): [number, number] => {
   const theta = Math.atan2(y, x);
 
   return [r, theta];
+};
+
+export const determinant2x2 = (matrix: Matrix2X2) => {
+  return matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0];
 };


### PR DESCRIPTION
I end up writing a lot of unnecessary code to create drawings with a variable offset because the current offset behavior only creates round line joins.  To improve this, I have added an optional argument to the offset function to specify an `Offset2DConfig` object wherein the caller can specify a `lineJoinType` as either `'round' | 'bevel' | 'miter'`, mirroring the SVG specification.  The default behavior is maintained as a `'round'` join.

The existing offset code was a bit difficult to wrap my head around but I ran it through several test drawings with acute/obtuse angles, arcs leading into lines, etc.  My code uses the _tangent_ at the last point of the previous curve and first point of the next curve to determine which direction to project a mitered line out from.

In order to determine the intersection of two lines from four points, I added some vector/matrix helpers including a `Matrix2X2` type and `determinant2x2` function.  If this functionality is already possible leveraging the utilities that already exist within replicad or OC, I'd much rather use that, but I'm not super familiar with the internals of the library yet.

Thank you so much for creating this.  I hope to collaborate more in the future as there are several more enhancements I have in mind.

Sam

<img width="1192" alt="Screenshot 2025-07-01 at 8 34 56 AM" src="https://github.com/user-attachments/assets/108f6f55-4658-43fe-b952-a4ac64b1e5d2" />
