### PR TITLE
Add a link in the docs to Leva, the UI toolkit.

### DIFF
--- a/packages/replicad-docs/docs/tutorial-overview/sharing-models.md
+++ b/packages/replicad-docs/docs/tutorial-overview/sharing-models.md
@@ -48,6 +48,11 @@ function main(
 }
 ```
 
+The `defaultParams` object allows for a wide variety of parameter types. It is
+built using the [Leva](https://github.com/pmndrs/leva) GUI library.
+See [Leva's "inputs" documentation](https://github.com/pmndrs/leva/blob/main/docs/inputs.md)
+for details about all the possibilities.
+
 When sharing with the share application, a simple form will be offered to the
 user to change the parameters and customise the shape.
 


### PR DESCRIPTION
As the title says. In my quest to make a more interesting parametric model, I discovered that Replicad uses Leva, and that Leva has support for a lot of interesting types of parameter definition. I figured it'd be nice to save the next newbie a bit of time and add a direct link in the docs to Leva.