### PR TITLE
feat: Add penPosition and penAngle getters to BaseSketcher2d

### DIFF
--- a/packages/replicad/src/Sketcher2d.ts
+++ b/packages/replicad/src/Sketcher2d.ts
@@ -82,6 +82,39 @@ export class BaseSketcher2d {
     return [u, v];
   }
 
+  /**
+   * Returns the current pen position as [x, y] coordinates
+   * 
+   * Added By Ben Harper 5/12/2025 
+
+   * @category Drawing State
+   */
+  get penPosition(): Point2D {
+    return this.pointer;
+  }
+
+  /**
+   * Returns the current pen angle in degrees
+   * 
+   * The angle represents the tangent direction at the current pen position,
+   * based on the last drawing operation (line, arc, bezier, etc.).
+   * Returns 0 if nothing has been drawn yet.
+   * 
+   * @category Drawing State
+   * 
+   * Added By Ben Harper 5/12/2025 to solve issue with being unable to draw a line perpendicular 
+   * to the tangent extension at the end of a .tangentArc() that did not finish at a known angle. 
+   */
+  get penAngle(): number {
+    if (this.pendingCurves.length === 0) return 0;
+    
+    const lastCurve = this.pendingCurves[this.pendingCurves.length - 1];
+    const [dx, dy] = lastCurve.tangentAt(1);
+    const angleInRadians = Math.atan2(dy, dx);
+    
+    return angleInRadians * RAD2DEG;
+  }
+
   movePointerTo(point: Point2D): this {
     if (this.pendingCurves.length)
       throw new Error(


### PR DESCRIPTION
- Add penPosition getter to expose current pen coordinates as Point2D
- Add penAngle getter to get current tangent angle in degrees
- Enables relative positioning and angle-based drawing operations

When drawing complex shapes, there was no way to query the current pen position or angle. This made it impossible (with my limited experience with replicad) to:
- Draw lines perpendicular to the current tangent
- Create closed shapes connecting arc endpoints
- Calculate relative angles for polar drawing operations

- Resolves issue with difficulty drawing say lines 'perpendicular to' rather than only 'tangent to' after arcs which to not end tangent to easily identified global angles.
- Updates in real-time as drawing operations are performed
Enables such use as this example - drawing a bent sheet of plytood:

const { draw } = replicad;
 {
const CreateBentPlywood = () => {
  let sketch = draw();  // Define upfront!
  const startpos = sketch.penPosition;
  sketch = sketch
    .vLine(5) 
    .hLine(-1)
    .tangentArc(-212, 103 - 8.5)
    .polarLine(5, sketch.penAngle + 90)
    .polarLine(5, sketch.penAngle + 90)
    .tangentArcTo(startpos)
    .close()   
    .sketchOnPlane()
    .extrude(500);
    return sketch
};

  const sheet1 = CreateBentPlywood()
  return [
    { shape: sheet1, name: "BentPlywood1", color: "brown" },
  ];  
   
}