### PR TITLE
feat: add draft (taper) angle via BRepOffsetAPI_DraftAngle

### DIFF
--- a/packages/replicad-opencascadejs/build-source/defaults.yml
+++ b/packages/replicad-opencascadejs/build-source/defaults.yml
@@ -229,6 +229,7 @@
     - symbol: BRepOffsetAPI_MakePipe
     - symbol: BRepOffsetAPI_MakePipeShell
     - symbol: BRepOffsetAPI_MakeFilling
+    - symbol: BRepOffsetAPI_DraftAngle
     - symbol: BRepOffset_Mode
     - symbol: BRepFilletAPI_LocalOperation
     - symbol: BRepFilletAPI_MakeFillet

--- a/packages/replicad/src/addThickness.ts
+++ b/packages/replicad/src/addThickness.ts
@@ -58,6 +58,55 @@ export const revolution = (
   return shape;
 };
 
+/**
+ * Apply a draft (taper) angle to all planar faces of a shape along a pull direction.
+ *
+ * @param shape - The shape to draft
+ * @param angle - Draft angle in degrees (positive = taper inward)
+ * @param direction - Pull direction (default: Z-up)
+ */
+export const draft = (
+  shape: Shape3D,
+  angle: number,
+  direction: Point = [0, 0, 1]
+): Shape3D => {
+  const oc = getOC();
+  const dir = new oc.gp_Dir_4(direction[0], direction[1], direction[2]);
+  const draftBuilder = new oc.BRepOffsetAPI_DraftAngle(shape.wrapped);
+
+  const explorer = new oc.TopExp_Explorer_2(
+    shape.wrapped,
+    oc.TopAbs_ShapeEnum.TopAbs_FACE as any,
+    oc.TopAbs_ShapeEnum.TopAbs_SHAPE as any
+  );
+
+  while (explorer.More()) {
+    const face = oc.TopoDS.Face_1(explorer.Current());
+    try {
+      draftBuilder.Add(face, dir, angle * DEG2RAD, oc.TopAbs_Orientation.TopAbs_FORWARD);
+    } catch {
+      // Skip faces that can't be drafted (non-planar, etc.)
+    }
+    explorer.Next();
+  }
+
+  draftBuilder.Build(new oc.Message_ProgressRange_1());
+  if (!draftBuilder.IsDone()) {
+    dir.delete();
+    explorer.delete();
+    draftBuilder.delete();
+    throw new Error("Draft operation failed");
+  }
+
+  const result = cast(draftBuilder.Shape());
+  dir.delete();
+  explorer.delete();
+  draftBuilder.delete();
+
+  if (!isShape3D(result)) throw new Error("Draft did not produce a 3D shape");
+  return result;
+};
+
 export interface GenericSweepConfig {
   frenet?: boolean;
   auxiliarySpine?: Wire | Edge;


### PR DESCRIPTION
## Summary

Adds a `draft()` function for applying taper angles to planar faces of a shape along a pull direction. This is essential for injection molding and casting design, where parts need draft angles to eject from molds.

## Usage

```typescript
import { makeBox, draft } from "replicad";

// 5° draft on all planar faces, pulling along Z axis
const box = makeBox(20, 20, 10);
const drafted = draft(box, 5);

// Custom pull direction
const drafted2 = draft(box, 3, [0, 0, 1]);
```

## Changes

**OCCT binding** (`packages/replicad-opencascadejs/build-source/defaults.yml`):
- Adds `BRepOffsetAPI_DraftAngle` symbol (1 line)

**JS wrapper** (`packages/replicad/src/addThickness.ts`):
- `draft(shape, angleDeg, pullDirection?)` — iterates planar faces, applies draft via OCCT, returns new shape
- Skips non-planar faces gracefully
- Cleans up OCCT objects (no memory leaks)

## Context

This came from building a browser-native CAD tool where users need draft angles for manufacturing features (Phase F in our roadmap). The OCCT `BRepOffsetAPI_DraftAngle` API is mature and well-documented — this just exposes it through replicad's JS layer.

**Note:** Requires a WASM rebuild to include the new OCCT symbol. The `defaults.yml` change is the only build config modification needed.

## Backward Compatible

New export only — no changes to existing APIs.