### PR TITLE
docs: clarify origin-relative solid positioning

### DIFF
--- a/packages/replicad/src/shapeHelpers.ts
+++ b/packages/replicad/src/shapeHelpers.ts
@@ -393,7 +393,7 @@ export const makeCylinder = (
 };
 
 /**
- * Creates a sphere with the given radius.
+ * Creates a sphere with the given radius, centred on the origin.
  *
  * @category Solids
  */
@@ -454,7 +454,7 @@ function convertToJSArray(arrayOfPoints: TColgp_Array2OfPnt): gp_Pnt[][] {
 }
 
 /**
- * Creates an ellipsoid with the given lengths of the axes.
+ * Creates an ellipsoid with the given lengths of the axes, centred on the origin.
  *
  * @category Solids
  */

--- a/packages/replicad/src/shortcuts.ts
+++ b/packages/replicad/src/shortcuts.ts
@@ -1,6 +1,20 @@
 import { Shape3D } from "./shapes";
 import Sketcher from "./Sketcher";
 
+/**
+ * Builds a rectangular box of the given lengths.
+ *
+ * The box is centred on the origin in X and Y (spanning `[-x/2, +x/2]` and
+ * `[-y/2, +y/2]`) and corner-based in Z (spanning `[0, +z]`). Translate by
+ * `[0, 0, -z/2]` to centre the box fully, or use {@link makeBox} when you
+ * want explicit two-corner control.
+ *
+ * @example
+ * const slab = makeBaseBox(30, 50, 10);
+ * // slab spans x: [-15, 15], y: [-25, 25], z: [0, 10]
+ *
+ * @category Solids
+ */
 export const makeBaseBox = (
   xLength: number,
   yLength: number,


### PR DESCRIPTION
## Summary

- Document that makeSphere and makeEllipsoid are centred on the origin.
- Document the mixed centre/corner positioning of makeBaseBox, including an example and links to makeBox for explicit corner control.
- Documentation only; no runtime behavior or public types change.

## Test plan

- [x] git diff --cached --check
- [x] Confirmed makeBaseBox and makeBox are present on upstream main
- [x] No runtime tests required for a JSDoc-only change

## Risks

- None. This changes generated API documentation only.

## AI Disclosure

- AI assistance used: yes
- Model: OpenAI Codex (GPT-5)
- Scope of AI assistance: diff isolation, validation, and PR drafting
- Human verification: confirmed.