### PR TITLE
Fix mesh reads above a 2GiB WASM heap

### DIFF
--- a/packages/replicad/src/shapes.ts
+++ b/packages/replicad/src/shapes.ts
@@ -451,27 +451,28 @@ export class Shape<Type extends TopoDS_Shape> extends WrappingObj<Type> {
     const heapU32 = new Uint32Array(buffer);
     const heapI32 = new Int32Array(buffer);
 
+    // The extractor exposes its pointers as signed 32 bit integers. Above 2GiB
+    // of heap they come back negative, which would make subarray() count from
+    // the end of the view; `>>> 0` reads them back as unsigned offsets.
+    const verticesPtr = raw.getVerticesPtr() >>> 0;
     const vertices = Array.from(
-      heapF32.subarray(
-        raw.getVerticesPtr() / 4,
-        raw.getVerticesPtr() / 4 + raw.getVerticesSize()
-      )
+      heapF32.subarray(verticesPtr / 4, verticesPtr / 4 + raw.getVerticesSize())
     );
+    const normalsPtr = raw.getNormalsPtr() >>> 0;
     const normals = Array.from(
-      heapF32.subarray(
-        raw.getNormalsPtr() / 4,
-        raw.getNormalsPtr() / 4 + raw.getNormalsSize()
-      )
+      heapF32.subarray(normalsPtr / 4, normalsPtr / 4 + raw.getNormalsSize())
     );
+    const trianglesPtr = raw.getTrianglesPtr() >>> 0;
     const trianglesRaw = heapU32.subarray(
-      raw.getTrianglesPtr() / 4,
-      raw.getTrianglesPtr() / 4 + raw.getTrianglesSize()
+      trianglesPtr / 4,
+      trianglesPtr / 4 + raw.getTrianglesSize()
     );
     const triangles = Array.from(trianglesRaw);
 
+    const faceGroupsPtr = raw.getFaceGroupsPtr() >>> 0;
     const groupsRaw = heapI32.subarray(
-      raw.getFaceGroupsPtr() / 4,
-      raw.getFaceGroupsPtr() / 4 + raw.getFaceGroupsSize()
+      faceGroupsPtr / 4,
+      faceGroupsPtr / 4 + raw.getFaceGroupsSize()
     );
     const faceGroups: { start: number; count: number; faceId: number }[] = [];
     for (let i = 0; i < groupsRaw.length; i += 3) {
@@ -514,16 +515,16 @@ export class Shape<Type extends TopoDS_Shape> extends WrappingObj<Type> {
     const heapF32 = new Float32Array(buffer);
     const heapI32 = new Int32Array(buffer);
 
+    // See the equivalent comment in mesh() about the signed pointers.
+    const linesPtr = raw.getLinesPtr() >>> 0;
     const lines = Array.from(
-      heapF32.subarray(
-        raw.getLinesPtr() / 4,
-        raw.getLinesPtr() / 4 + raw.getLinesSize()
-      )
+      heapF32.subarray(linesPtr / 4, linesPtr / 4 + raw.getLinesSize())
     );
 
+    const edgeGroupsPtr = raw.getEdgeGroupsPtr() >>> 0;
     const groupsRaw = heapI32.subarray(
-      raw.getEdgeGroupsPtr() / 4,
-      raw.getEdgeGroupsPtr() / 4 + raw.getEdgeGroupsSize()
+      edgeGroupsPtr / 4,
+      edgeGroupsPtr / 4 + raw.getEdgeGroupsSize()
     );
     const edgeGroups: { start: number; count: number; edgeId: number }[] = [];
     for (let i = 0; i < groupsRaw.length; i += 3) {


### PR DESCRIPTION
### Cause

`ReplicadMeshExtractor` / `ReplicadEdgeMeshExtractor` expose their buffer
pointers as `int` (`mesh-extractor.cpp` does
`static_cast<int>(reinterpret_cast<uintptr_t>(...))`). Once the WASM heap grows
past 2GiB (2^31), those pointers come back **negative** in JS, and
`TypedArray.prototype.subarray()` treats a negative start as an offset from the
*end* of the view — so `mesh()` and `meshEdges()` read from a completely
different region of the heap.

The geometry itself is fine. Only the JS-side read is wrong. This PR coerces
each of the six pointers with `>>> 0` before the `/ 4`, in a local that is then
used for both the start and the end expression (which also removes the double
getter call each of them had).

The existing comment about `memory.grow()` detaching cached `HEAP*` views is
untouched — the views are already taken correctly *after* `extract()` returns;
this is the neighbouring problem of the pointer *value* rather than the view.

### Decisive evidence

One extraction, two interpretations — same pointer values, same buffer, the only
difference being `>>> 0`. Sphere of r = 50, heap grown past 2GiB:

```
getVerticesPtr() = -2129330176

read as today (signed):   50420 / 50420 vertices lie off the sphere, maxIdx = 0
read with `>>> 0`:            0 / 50420 vertices lie off the sphere,
                          maxIdx = 50419, coordinates all within -50..50
```

An independent audit through the OCCT API on both sides of the 2GiB threshold is
**identical** (50 420 nodes, 100 520 triangles), which confirms the solid is
whole and only the read is affected.

### Warning: the defect has two faces

Depending on where the bad offset lands, the same bug shows up in two very
different ways:

1. garbage coordinates and out-of-range triangle indices, or
2. **a mesh of all zeros**, when the read lands in a freshly grown, not yet
   written region of the heap.

Case 2 is the trap: zero is an in-range index and a finite coordinate, so the
obvious sanity checks (finite numbers, indices within `vertices.length / 3`,
non-empty arrays) all **pass**. Our first verdict was "not reproduced" under
conditions that were in fact fully reproducing the bug. Vertices have to be
compared against the **intended shape**, not just checked for plausibility.

### How to check it in ~25 s

No large model is needed — only a big heap:

1. `initOpenCascade()` from a 4GiB-capable build (the current
   `custom_build_single.yml` / `custom_build_multi.yml` both use
   `-sMAXIMUM_MEMORY=4GB`, so the released `replicad-opencascadejs@1.0.0`
   qualifies).
2. Grow the heap past 2GiB with a plain `_malloc` loop (no real geometry
   required).
3. `makeSphere(50)`, then `.mesh()`.
4. Count vertices failing `Math.abs(norm(v) - 50) < tol`.

Before the patch that count is every vertex (or all coordinates are zero); after
it, zero.

### Why 0.23.0 is not affected

That build caps the heap at 2GiB, so the code path is unreachable, and the old
`mesh()` read the triangulation through the OCCT API — no raw pointer crossed
into JS.

### A more thorough fix

`packages/replicad-opencascadejs/build-config/wrappers/mesh-extractor.cpp` could
bind those getters as an **unsigned** type, which would protect every consumer of
the extractor at once rather than just this call site. That needs a WASM rebuild,
so this PR does the smaller, immediately mergeable thing on the JS side instead.

### Not verified

- Other pointer reads in the library. A grep over `packages/*/src` found no
  further `subarray` / `HEAP*` pointer reads, but this was not audited
  exhaustively.
- The multi-threaded build.
- Your full CI. Locally, on the `replicad` package alone (deps installed from
  npm): `tsc --noEmit` clean, `vitest --run` 40/40 passing, `eslint` with the
  repo config reports no new findings, and `prettier` produces no changes inside
  the touched hunks. No test was added: reproducing this requires a heap above
  2GiB, which is unlikely to be acceptable in CI.
