### PR TITLE
Allow skipping SimplifyResult in boolean operations

### DIFF
--- a/packages/replicad/__tests__/boolean-simplify.test.ts
+++ b/packages/replicad/__tests__/boolean-simplify.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import { FaceFinder, makeBaseBox, measureVolume } from "../src/index";
+
+/**
+ * Booleans end with `SimplifyResult`, which merges coplanar faces. That is usually what you
+ * want, but on some shapes it turns a valid solid into an invalid one, and the damage only
+ * surfaces later: a subsequent boolean returns an empty result while reporting no error.
+ *
+ * `simplify: false` gives callers a way out. Two boxes sharing a face make the effect easy to
+ * see: simplified, the union is a single box (6 faces); unsimplified, the shared plane stays
+ * split, so there are more.
+ */
+const faces = (shape: any): number => new FaceFinder().find(shape).length;
+
+const twoBoxes = (): [any, any] => [
+  makeBaseBox(10, 10, 10),
+  makeBaseBox(10, 10, 10).translate([10, 0, 0]),
+];
+
+test("fuse simplifies coplanar faces by default", () => {
+  const [a, b] = twoBoxes();
+  expect(faces(a.fuse(b))).toBe(6);
+});
+
+test("fuse keeps the untouched result when simplify is false", () => {
+  const [a, b] = twoBoxes();
+  expect(faces(a.fuse(b, { simplify: false }))).toBeGreaterThan(6);
+});
+
+test("fuse with simplify: false preserves the volume", () => {
+  const [a, b] = twoBoxes();
+  const [c, d] = twoBoxes();
+  expect(measureVolume(c.fuse(d, { simplify: false }))).toBeCloseTo(
+    measureVolume(a.fuse(b)),
+    6
+  );
+});
+
+test("cut and intersect accept the same option", () => {
+  const box = () => makeBaseBox(10, 10, 10);
+  const tool = () => makeBaseBox(4, 4, 40).translate([0, 0, -20]);
+  expect(measureVolume(box().cut(tool(), { simplify: false }))).toBeCloseTo(
+    measureVolume(box().cut(tool())),
+    6
+  );
+  expect(measureVolume(box().intersect(tool(), { simplify: false }))).toBeCloseTo(
+    measureVolume(box().intersect(tool())),
+    6
+  );
+});

--- a/packages/replicad/src/shapes.ts
+++ b/packages/replicad/src/shapes.ts
@@ -1051,7 +1051,11 @@ export class _3DShape<Type extends TopoDS_Shape>
     other: Shape3D,
     {
       optimisation = "none",
-    }: { optimisation?: "none" | "commonFace" | "sameFace" } = {}
+      simplify = true,
+    }: {
+      optimisation?: "none" | "commonFace" | "sameFace";
+      simplify?: boolean;
+    } = {}
   ): Shape3D {
     const r = GCWithScope();
     const newBody = r(
@@ -1065,7 +1069,7 @@ export class _3DShape<Type extends TopoDS_Shape>
     }
 
     newBody.Build();
-    newBody.SimplifyResult(true, true, 1e-3);
+    if (simplify) newBody.SimplifyResult(true, true, 1e-3);
     const newShape = cast(newBody.Shape());
     if (!isShape3D(newShape)) throw new Error("Could not fuse as a 3d shape");
 
@@ -1081,7 +1085,11 @@ export class _3DShape<Type extends TopoDS_Shape>
     tool: Shape3D,
     {
       optimisation = "none",
-    }: { optimisation?: "none" | "commonFace" | "sameFace" } = {}
+      simplify = true,
+    }: {
+      optimisation?: "none" | "commonFace" | "sameFace";
+      simplify?: boolean;
+    } = {}
   ): Shape3D {
     const r = GCWithScope();
     const cutter = r(new this.oc.BRepAlgoAPI_Cut(this.wrapped, tool.wrapped));
@@ -1092,7 +1100,7 @@ export class _3DShape<Type extends TopoDS_Shape>
       cutter.SetGlue(this.oc.BOPAlgo_GlueEnum.BOPAlgo_GlueFull);
     }
     cutter.Build();
-    cutter.SimplifyResult(true, true, 1e-3);
+    if (simplify) cutter.SimplifyResult(true, true, 1e-3);
 
     const newShape = cast(cutter.Shape());
     if (!isShape3D(newShape)) throw new Error("Could not cut as a 3d shape");
@@ -1104,13 +1112,16 @@ export class _3DShape<Type extends TopoDS_Shape>
    *
    * @category Shape Modifications
    */
-  intersect(tool: AnyShape): Shape3D {
+  intersect(
+    tool: AnyShape,
+    { simplify = true }: { simplify?: boolean } = {}
+  ): Shape3D {
     const r = GCWithScope();
     const intersector = r(
       new this.oc.BRepAlgoAPI_Common(this.wrapped, tool.wrapped)
     );
     intersector.Build();
-    intersector.SimplifyResult(true, true, 1e-3);
+    if (simplify) intersector.SimplifyResult(true, true, 1e-3);
 
     const newShape = cast(intersector.Shape());
     if (!isShape3D(newShape))


### PR DESCRIPTION
Fixes #272.

Booleans end with an unconditional `newBody.SimplifyResult(true, true, 1e-3)`. On some shapes that step turns a **valid** solid into an **invalid** one, and the damage is silent — a later boolean on it returns an empty result while reporting `HasErrors() === false` and `IsDone() === true`. #272 has a self-contained reproduction.

This adds a `simplify` option to `fuse`, `cut` and `intersect`. It defaults to `true`, so nothing changes for existing callers; it only gives people hitting the problem a way out.

```ts
const blank = half.fuse(half.mirror("YZ", [382.2, 0, 0]), { simplify: false });
```

### Measurements

Taken on the affected shapes (a lofted picture-frame moulding, 23 shape/size combinations):

| | with simplification | without |
|---|---|---|
| solid valid | 14 / 23 | **23 / 23** |
| volume | — | unchanged (largest difference 0.00213 %, usually 0.00000 %) |
| face count | baseline | +4–5 % on curved shapes, +89 % on a straight one |
| time of the union | baseline | **9–16 % faster** |

### Why not verify and fall back instead

Checking the simplified result and reverting when it is invalid would fix everyone without an API change, so I measured it. `BRepCheck_Analyzer` costs **16–38 % of the boolean itself** (29 ms against a 77 ms union; 269 ms against 1626 ms; 367 ms against 2341 ms), which makes the safe variant **7–22 % more expensive on every boolean for every user** — to rescue a minority of shapes.

That trade-off felt like yours to make rather than mine, so this PR takes the cheap route. Happy to switch to the verify-and-fall-back version, or to make it a third mode (`simplify: "safe"`), if you prefer.

### Checks

- `tsc --noEmit` clean
- `vitest run` in `packages/replicad`: **53 passed** (49 existing + 4 new in `__tests__/boolean-simplify.test.ts`)
