### PR TITLE
Use tighter bounding box logic

### DIFF
--- a/packages/replicad/src/shapes.ts
+++ b/packages/replicad/src/shapes.ts
@@ -434,7 +434,7 @@ export class Shape<Type extends TopoDS_Shape> extends WrappingObj<Type> {
 
   get boundingBox(): BoundingBox {
     const bbox = new BoundingBox();
-    this.oc.BRepBndLib.Add(this.wrapped, bbox.wrapped, true);
+    this.oc.BRepBndLib.AddOptimal(this.wrapped, bbox.wrapped, false, false);
     return bbox;
   }
 


### PR DESCRIPTION
The BRepBndLib.Add method which was used includes the full extent of BSpline surfaces which are part of a shape's construction. This is sometimes correct but in other cases can vastly overstate a shape's bounding box.

A typical example here is a small part trimmed by some larger BSpline surface, eg: a fastener trimmed by a boat hull. In this case the trimmed face of the bolt is defined by the same underlying surface as the (much larger) boat hull. By default the .Add method includes in the bbox the full extent of that underlying surface not just the part of the surface which is co-incident with the trimmed part.

Using AddOptimal (link: https://occt3d.com/dev/doc/refman/html/class_b_rep_bnd_lib.html) fixes this. Notably the `useTriangulation` can be left as false and we still get the updated behavior so (I think) this impl doesn't do the extra work of triangulation.

Here's an example workspace which highlights the issue:
 https://studio.replicad.xyz/workbench#code=UEsDBAoAAAAIAFegH11GNqz3LgIAAIkEAAAHAAAAY29kZS5qc31TYWvbMBD9nl8h8kkeilanCYyVDuouZYWyhKRjW4MZin1OtdqSkRScUfrfd5bTWCljOOC7p6e7d8%252BXTCvryDPJjWgWRv%252BGzEmtGOnja1GBEcwzGJnlW2DkM8ZSbckLuSQG6lJmIr8YDDJfrBJSIU4jcvmJPA8I6eCNAZG7RzwZTy6OaAlq68F4gugRNtg7qM3b5kvEhNqWQOMzRqYRt0%252Fgsse5WpRCAR3%252B%252BDmMOOyd2eVIibgzQtlSOKBT5Hd3gha1lspZbLJGiJA1nre%252FlHXpQdg7csYnU3ZU%252F56MGRmd%252F4P14bxntTmmozGfnjJ9j1HswTQQY%252BNw2ko8QbLCRMFVXRu9l5VoPwXtNAejPaAXUe9mc1JGWAvVpoTv0gBd2ziNeuL4f8Sw%252FmgScaOdt5G1LuGTYhD7IEpDS3UWVt2Cm1%252FT8NzuTEEuj4RSF46um5g140CatNmu%252B%252FaZ4xjS9lYUFKkhk6K8k7ZlrYfJ7OF2tvy1%252Bra8ubqeDRkZJqvF3e3XWQjNb25Ws%252FsT5P5LcCt99VCXgLq21KvghcjAcqsroLQ47vMps8BBdXX%252Fp4bInxlwO6NCmVyqrMSltG%252B4L9FxrNdiw81G74kuSOsBhh8Jau20bPRO5finS%252FS%252Bi23vmYOqRjMUNL39Sc%252BnLVNnPFlCnaj8Tm74VZ7Pa4d7VR5GbYyoa8iZr9VnhSgtHF7RW5PeqiWNxOUXea670l69r9cLPtiz9l1ZtxLp4GXwF1BLAQIUAAoAAAAIAFegH11GNqz3LgIAAIkEAAAHAAAAAAAAAAAAAAAAAAAAAABjb2RlLmpzUEsFBgAAAAABAAEANQAAAFMCAAAAAA%253D%253D 