### PR TITLE
Fix contour grouping when holes precede their outer boundary

### DIFF
--- a/packages/replicad/__tests__/drawing/contour-groups.test.ts
+++ b/packages/replicad/__tests__/drawing/contour-groups.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "vitest";
+import {
+  CompoundBlueprint,
+  drawRectangle,
+  measureVolume,
+  organiseBlueprints,
+} from "../../src/index";
+
+function permutations<T>(items: T[]): T[][] {
+  if (items.length === 0) return [[]];
+  return items.flatMap((item, index) =>
+    permutations(items.filter((_, i) => i !== index)).map((rest) => [
+      item,
+      ...rest,
+    ])
+  );
+}
+
+test.each(permutations([0, 1, 2]).map((order) => ({ order })))(
+  "groups two holes with their outer contour in order $order",
+  ({ order }) => {
+    // The holes are disjoint, but both overlap the outer contour's bounds.
+    // With holes first, the outer contour must join their earlier groups.
+    const contours = [
+      drawRectangle(2, 2).translate(-2, 0).blueprint,
+      drawRectangle(2, 2).translate(2, 0).blueprint,
+      drawRectangle(10, 10).blueprint,
+    ];
+    try {
+      const profiles = organiseBlueprints(order.map((i) => contours[i]));
+      expect(profiles.blueprints).toHaveLength(1);
+      const profile = profiles.blueprints[0];
+      expect(profile).toBeInstanceOf(CompoundBlueprint);
+      if (!(profile instanceof CompoundBlueprint)) {
+        throw new Error("Expected an outer contour with two holes");
+      }
+      expect(profile.blueprints[0]).toBe(contours[2]);
+      expect(new Set(profile.blueprints.slice(1))).toEqual(
+        new Set(contours.slice(0, 2))
+      );
+
+      const solid = profiles.sketchOnPlane("XY").extrude(1);
+      try {
+        expect(measureVolume(solid)).toBeCloseTo(92, 6);
+      } finally {
+        solid.delete();
+      }
+    } finally {
+      contours.forEach((contour) => contour.delete());
+    }
+  }
+);
+
+test.each(permutations([0, 1, 2, 3]).map((order) => ({ order })))(
+  "preserves a nested island and its hole in order $order",
+  ({ order }) => {
+    const contours = [12, 10, 6, 2].map(
+      (size) => drawRectangle(size, size).blueprint
+    );
+    try {
+      const profiles = organiseBlueprints(order.map((i) => contours[i]));
+      expect(profiles.blueprints).toHaveLength(2);
+      for (const profile of profiles.blueprints) {
+        expect(profile).toBeInstanceOf(CompoundBlueprint);
+        if (profile instanceof CompoundBlueprint) {
+          expect(profile.blueprints).toHaveLength(2);
+        }
+      }
+      const solid = profiles.sketchOnPlane("XY").extrude(1);
+      try {
+        expect(measureVolume(solid)).toBeCloseTo(76, 6);
+      } finally {
+        solid.delete();
+      }
+    } finally {
+      contours.forEach((contour) => contour.delete());
+    }
+  }
+);
+
+test.each(permutations([0, 1, 2, 3]).map((order) => ({ order })))(
+  "keeps disconnected regions and their holes separate in order $order",
+  ({ order }) => {
+    const contours = [
+      drawRectangle(2, 2).translate(-10, 0).blueprint,
+      drawRectangle(2, 2).translate(10, 0).blueprint,
+      drawRectangle(10, 10).translate(-10, 0).blueprint,
+      drawRectangle(10, 10).translate(10, 0).blueprint,
+    ];
+    try {
+      const profiles = organiseBlueprints(order.map((i) => contours[i]));
+      const firstRegion = order[0] % 2;
+      expect(profiles.blueprints).toHaveLength(2);
+      profiles.blueprints.forEach((profile, index) => {
+        expect(profile).toBeInstanceOf(CompoundBlueprint);
+        if (profile instanceof CompoundBlueprint) {
+          const region = (firstRegion + index) % 2;
+          expect(profile.blueprints).toEqual([
+            contours[region + 2],
+            contours[region],
+          ]);
+        }
+      });
+      const solid = profiles.sketchOnPlane("XY").extrude(1);
+      try {
+        expect(measureVolume(solid)).toBeCloseTo(192, 6);
+      } finally {
+        solid.delete();
+      }
+    } finally {
+      contours.forEach((contour) => contour.delete());
+    }
+  }
+);
+
+test("handles empty and single-contour inputs", () => {
+  expect(organiseBlueprints([]).blueprints).toEqual([]);
+  const contour = drawRectangle(10, 10).blueprint;
+  try {
+    expect(organiseBlueprints([contour]).blueprints).toEqual([contour]);
+  } finally {
+    contour.delete();
+  }
+});

--- a/packages/replicad/src/blueprints/lib.ts
+++ b/packages/replicad/src/blueprints/lib.ts
@@ -11,33 +11,33 @@ import { SketchInterface } from "../sketches/lib";
 import Sketches from "../sketches/Sketches";
 
 const groupByBoundingBoxOverlap = (blueprints: Blueprint[]): Blueprint[][] => {
-  const overlaps = blueprints.map((blueprint, i) => {
-    return blueprints
-      .slice(i + 1)
-      .map((v, j): [number, Blueprint] => [j + i + 1, v])
-      .filter(([, other]) => !blueprint.boundingBox.isOut(other.boundingBox))
-      .map(([index]) => index);
-  });
-  const groups: Blueprint[][] = [];
-  const groupsInOverlaps = Array(overlaps.length);
-
-  overlaps.forEach((indices, i) => {
-    let myGroup = groupsInOverlaps[i];
-    if (!myGroup) {
-      myGroup = [];
-      groups.push(myGroup);
+  const parents = blueprints.map((_, index) => index);
+  const root = (index: number): number => {
+    while (parents[index] !== index) {
+      parents[index] = parents[parents[index]];
+      index = parents[index];
     }
+    return index;
+  };
 
-    myGroup.push(blueprints[i]);
-
-    if (indices.length) {
-      indices.forEach((index) => {
-        groupsInOverlaps[index] = myGroup;
-      });
+  // A later contour can connect multiple previously separate groups.
+  for (let i = 0; i < blueprints.length; i++) {
+    for (let j = i + 1; j < blueprints.length; j++) {
+      if (!blueprints[i].boundingBox.isOut(blueprints[j].boundingBox)) {
+        parents[root(j)] = root(i);
+      }
     }
-  });
+  }
 
-  return groups;
+  // Preserve input order within groups and first-seen order between groups.
+  const groups = new Map<number, Blueprint[]>();
+  blueprints.forEach((blueprint, index) => {
+    const key = root(index);
+    const group = groups.get(key);
+    if (group) group.push(blueprint);
+    else groups.set(key, [blueprint]);
+  });
+  return Array.from(groups.values());
 };
 
 interface ContainedBlueprint {


### PR DESCRIPTION
When two disjoint holes appear before their enclosing contour, `organiseBlueprints` can treat one hole as a separate filled region. This also affects text glyphs such as DejaVu Sans `B`, producing overlapping solids and incorrect embossed or engraved text.

`groupByBoundingBoxOverlap` assigns a tentative group to later overlapping contours. When both holes overlap the same outer contour, the second assignment overwrites the first without merging the existing groups. Containment is then evaluated separately, so one hole loses its outer boundary.

This change joins connected bounding-box groups with a disjoint-set structure before collecting contours. It preserves input order within groups and first-seen group order. The existing containment and geometry-building logic remains in use.

### Minimal reproduction

No font file is needed:

```js
const main = ({ drawRectangle, organiseBlueprints }) => {
  const contours = [
    drawRectangle(2, 2).translate(-2, 0).blueprint,
    drawRectangle(2, 2).translate(2, 0).blueprint,
    drawRectangle(10, 10).blueprint,
  ];
  return organiseBlueprints(contours).sketchOnPlane("XY").extrude(1);
};
```

The expected result is one solid with two holes and volume 92. Before this change, the result contains two overlapping solids with a summed volume of 100 and only one recognized hole.

### Validation

- Added 55 regression cases covering all input permutations for two holes, a nested island with its own hole, and disconnected regions, plus empty/single-contour inputs. The tests check contour membership, ordering, and extruded volumes.
- Confirmed the two holes-first permutations fail before the fix and all 55 cases pass afterward.
- `npm run prepare-packages`
- `npm test` — all 163 tests pass across the four tested workspaces.
- `npm run typecheck`
- `npm run build --workspace=studio`
- `npm run build --workspace=replicad-app-example`
- Prettier check on both changed files and `git diff --check`.
